### PR TITLE
Implementation of let*.

### DIFF
--- a/src/Lisphp/Environment.php
+++ b/src/Lisphp/Environment.php
@@ -16,6 +16,7 @@ final class Lisphp_Environment
         $scope['define'] = new Lisphp_Runtime_Define;
         $scope['setf!'] = new Lisphp_Runtime_Setf;
         $scope['let'] = new Lisphp_Runtime_Let;
+        $scope['let*'] = new Lisphp_Runtime_LetStar;
         $scope['macro'] = new Lisphp_Runtime_Macro;
         $scope['lambda'] = new Lisphp_Runtime_Lambda;
         $scope['apply'] = new Lisphp_Runtime_Apply;

--- a/src/Lisphp/Runtime/LetStar.php
+++ b/src/Lisphp/Runtime/LetStar.php
@@ -1,0 +1,19 @@
+<?php
+
+final class Lisphp_Runtime_LetStar implements Lisphp_Applicable
+{
+    public function apply(Lisphp_Scope $scope, Lisphp_List $arguments)
+    {
+        $vars = $arguments->car();
+        $scope = new Lisphp_Scope($scope);
+        foreach ($vars as $var) {
+            list($var, $value) = $var;
+            $scope->let($var, $value->evaluate($scope));
+        }
+        foreach ($arguments->cdr() as $form) {
+            $retval = $form->evaluate($scope);
+        }
+
+        return $retval;
+    }
+}

--- a/tests/Lisphp/RuntimeTest.php
+++ b/tests/Lisphp/RuntimeTest.php
@@ -76,6 +76,19 @@ class Lisphp_RuntimeTest extends Lisphp_TestCase
         $this->assertNull($scope['b']);
     }
 
+    public function testLetStar()
+    {
+        $letStar = new Lisphp_Runtime_LetStar;
+        $scope = Lisphp_Environment::sandbox();
+        $scope['a'] = 1;
+        $scope['c'] = 1;
+        $retval = $letStar->apply(
+            $scope,
+            self::lst('[(x 5) (y (+ x 1))] y')
+        );
+        $this->assertEquals(6, $retval);
+    }
+
     public function testQuote()
     {
         $quote = new Lisphp_Runtime_Quote;


### PR DESCRIPTION
let\* is a standard lisp function that lets you set local variables that can refer
to each other.
