### PR TITLE
Fix tests on PHP greater than 5.3

### DIFF
--- a/src/Lisphp/Literal.php
+++ b/src/Lisphp/Literal.php
@@ -35,6 +35,7 @@ final class Lisphp_Literal implements Lisphp_Form
 
     public function __toString()
     {
-        return var_export($this->value, true);
+        if ($this->isString()) return var_export($this->value, true);
+        else return (string) $this->value;
     }
 }


### PR DESCRIPTION
Looks like since version 5.4.22 var_export uses the serialize_precision
ini setting, rather than the precision one used for normal output of
floating-point numbers.  As a consequence since version 5.4.22 for
example var_export(1.1) will output 1.1000000000000001 (17 is default
precision value) and not 1.1 as before.
